### PR TITLE
Fixup style in arducam

### DIFF
--- a/IceStick/arducam.py
+++ b/IceStick/arducam.py
@@ -1,115 +1,137 @@
-from magma import *
+import magma as m
+from magma import I0, I1, I2, I3
 from magma.bitutils import int2seq
 from mantle.util.edge import falling, rising
-from mantle import *
+import mantle
 from rom import ROM16
 from uart import UART
 
-
-trigger = 1 # maybe tie to GPIO later
+trigger = 1  # maybe tie to GPIO later
 
 # ArduCAM start capture sequence
-init = [array(int2seq(0x8200,16)), 							  # Change MCU mode
-        array(int2seq(0x8401,16)), array(int2seq(0x8401,16)), array(int2seq(0x8402,16)), # Start capture
-        array(int2seq(0x4100,16)), 							  # check capture completion flag
-        array(int2seq(0x4200,16)), array(int2seq(0x4300,16)), array(int2seq(0x4400,16)), # Read image length
-        array(int2seq(0x3CFF,16)), array(int2seq(0x0000,16)), # burst read 
-        array(int2seq(0x0000,16)), array(int2seq(0x0000,16)),
-        array(int2seq(0x0000,16)), array(int2seq(0x0000,16)),
-        array(int2seq(0x0000,16)), array(int2seq(0x0000,16))]
+init = [
+    # Change MCU mode
+    m.array(int2seq(0x8200, 16)),
+    # Start capture
+    m.array(int2seq(0x8401, 16)),
+    m.array(int2seq(0x8401, 16)),
+    m.array(int2seq(0x8402, 16)),
+    # check capture completion flag
+    m.array(int2seq(0x4100, 16)),
+    # Read image length
+    m.array(int2seq(0x4200, 16)),
+    m.array(int2seq(0x4300, 16)),
+    m.array(int2seq(0x4400, 16)),
+    # burst read
+    m.array(int2seq(0x3CFF, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16)),
+    m.array(int2seq(0x0000, 16))
+]
 
 
 # Read ROM unit
-class ArduCAM(Circuit):
+class ArduCAM(m.Circuit):
     name = "ArduCAM"
-    IO = ['CLK', In(Clock), 'SCK', In(Bit), 'MISO', In(Bit),
-          'EN', Out(Bit), 'MOSI', Out(Bit), 'DATA', Out(Bits(8)), 'VALID', Out(Bit), 'UART', Out(Bit), 'DONE', Out(Bit)]
+    IO = ['CLK', m.In(m.Clock), 'SCK', m.In(m.Bit), 'MISO', m.In(m.Bit),
+          'EN', m.Out(m.Bit), 'MOSI', m.Out(m.Bit), 'DATA', m.Out(m.Bits(8)),
+          'VALID', m.Out(m.Bit), 'UART', m.Out(m.Bit), 'DONE', m.Out(m.Bit)]
+
     @classmethod
     def definition(cam):
         edge_f = falling(cam.SCK)
         edge_r = rising(cam.SCK)
 
         # ROM to store commands
-        rom_index = Counter(4, has_ce=True)
+        rom_index = mantle.Counter(4, has_ce=True)
         rom = ROM16(4, init, rom_index.O)
 
-        # Message length is 16 bits, setup counter to generate done signal after EOM
-        done_counter = Counter(5, has_ce=True, has_reset=True)
+        # Message length is 16 bits, setup counter to generate done signal
+        # after EOM
+        done_counter = mantle.Counter(5, has_ce=True, has_reset=True)
         count = done_counter.O
-        done = Decode(16, 5)(count)
+        done = mantle.Decode(16, 5)(count)
 
         # State machine to generate run signal (enable)
-        run = DFF(has_ce=True)
-        run_n = LUT3([0,0,1,0, 1,0,1,0])
+        run = mantle.DFF(has_ce=True)
+        run_n = mantle.LUT3([0, 0, 1, 0, 1, 0, 1, 0])
         run_n(done, trigger, run)
         run(run_n)
-        wire(edge_f, run.CE)
+        m.wire(edge_f, run.CE)
 
         # Reset the message length counter after done
-        run_reset = LUT2(I0|~I1)(done, run)
+        run_reset = mantle.LUT2(I0 | ~I1)(done, run)
         done_counter(CE=edge_r, RESET=run_reset)
 
         # State variables for high-level state machine
-        ready = LUT2(~I0 & I1)(run, edge_f)
-        start = ULE(4)(rom_index.O, uint(3,4))
-        burst = UGE(4)(rom_index.O, uint(9,4))
+        ready = mantle.LUT2(~I0 & I1)(run, edge_f)
+        start = mantle.ULE(4)(rom_index.O, m.uint(3, 4))
+        burst = mantle.UGE(4)(rom_index.O, m.uint(9, 4))
 
         # Shift register to store 16-bit command|data to send
-        mosi = PISO(16, has_ce=True)
-        # SPI enable is negative of load-don't load and shift out data at the same time
-        enable = LUT3(I0 & ~I1 & ~I2)(trigger, run, burst) 
+        mosi = mantle.PISO(16, has_ce=True)
+        # SPI enable is negative of load-don't load and shift out data at the
+        # same time
+        enable = mantle.LUT3(I0 & ~I1 & ~I2)(trigger, run, burst)
         mosi(~burst, rom.O, enable)
-        wire(edge_f, mosi.CE)
+        m.wire(edge_f, mosi.CE)
 
-        # Shit register to read in 8-bit data 
-        miso = SIPO(8, has_ce=True)
+        # Shit register to read in 8-bit data
+        miso = mantle.SIPO(8, has_ce=True)
         miso(cam.MISO)
-        valid = LUT2(~I0 & I1)(enable, edge_r)
-        wire(valid, miso.CE)    
+        valid = mantle.LUT2(~I0 & I1)(enable, edge_r)
+        m.wire(valid, miso.CE)
 
         # Capture done state variable
-        cap_done = SRFF(has_ce=True)
-        cap_done(EQ(8)(miso.O, bits(0x08, 8)), 0)
-        wire(enable&edge_r, cap_done.CE)
+        cap_done = mantle.SRFF(has_ce=True)
+        cap_done(mantle.EQ(8)(miso.O, m.bits(0x08, 8)), 0)
+        m.wire(enable & edge_r, cap_done.CE)
 
         # Use state variables to determine what commands are sent (how)
-        increment = LUT4(I0 & (I1 | I2) & ~I3)(ready, start, cap_done, burst)
-        wire(increment, rom_index.CE)
+        increment = mantle.LUT4(I0 & (I1 | I2) & ~I3)(
+            ready, start, cap_done, burst)
+        m.wire(increment, rom_index.CE)
 
         # wire outputs
-        wire(enable,  cam.EN)
-        wire(mosi.O,  cam.MOSI)
-        wire(miso.O,  cam.DATA)
-        wire(burst,   cam.VALID)
+        m.wire(enable, cam.EN)
+        m.wire(mosi.O, cam.MOSI)
+        m.wire(miso.O, cam.DATA)
+        m.wire(burst,  cam.VALID)
 
-        #---------------------------UART OUTPUT-----------------------------#
+        # ---------------------------UART OUTPUT----------------------------- #
 
         # run UART at 2x SPI rate to allow it to keep up
         baud = edge_r | edge_f
 
-        # reset when SPI burst read (image transfer) begins 
-        ff = FF(has_ce=True)
-        wire(edge_r, ff.CE)
-        u_reset = LUT2(I0 & ~I1)(burst, ff(burst))
+        # reset when SPI burst read (image transfer) begins
+        ff = mantle.FF(has_ce=True)
+        m.wire(edge_r, ff.CE)
+        u_reset = mantle.LUT2(I0 & ~I1)(burst, ff(burst))
 
         # UART data out every 8 bits
-        u_counter = CounterModM(8, 3, has_ce=True, has_reset=True)
+        u_counter = mantle.CounterModM(8, 3, has_ce=True, has_reset=True)
         u_counter(CE=edge_r, RESET=u_reset)
         load = burst & rising(u_counter.COUT)
 
-        uart = UART(8)
-        uart(CLK=cam.CLK, BAUD=baud, DATA=miso, LOAD=load) #quick hack to build
+        uart = mantle.UART(8)
+
+        # quick hack to build
+        uart(CLK=cam.CLK, BAUD=baud, DATA=miso, LOAD=load)
 
         # wire output
-        wire(uart, cam.UART) 
+        m.wire(uart, cam.UART)
 
         # generate signal for when transfer is done
-        data_count = Counter(18, has_ce=True)
-        tx_done = SRFF(has_ce=True)
+        data_count = mantle.Counter(18, has_ce=True)
+        tx_done = mantle.SRFF(has_ce=True)
         # transfer has size 153600 bytes, first 2 bytes are ignored
-        tx_done(EQ(18)(data_count.O, bits(153602, 18)), 0)
-        wire(load, tx_done.CE)
-        wire(load, data_count.CE)
+        tx_done(mantle.EQ(18)(data_count.O, m.bits(153602, 18)), 0)
+        m.wire(load, tx_done.CE)
+        m.wire(load, data_count.CE)
 
         # wire output
-        wire(tx_done, cam.DONE)
+        m.wire(tx_done, cam.DONE)


### PR DESCRIPTION
Our projects have moved to using pep8 as a style format for general Python code. It's a good idea to just follow a guideline for this. https://www.python.org/dev/peps/pep-0008/

You could install the sublime linter plugin to run pep8 checks while your coding: https://github.com/SublimeLinter/SublimeLinter

Overall this module looks good, I would add two things:
* break up the body of the definition into helper functions/modules. You did a good job adding comments for each section, but it would be nice to decompose this into smaller functions/module for organization. For example, you could move the uart logic into a separate function or module. Helper function would be simpler, since it effectively just inlines the code into the definition (basically this just allows you to write reusable logic for defining circuits). Helper modules make more sense if you want the structure to be preserved in the actual circuit definition (helper functions just add instances and wires to the current definition, whereas a helper module will encapsulate that logic in a separate definition).
* some documentation of the overall architecture. A block diagram might be nice here, but basically explain what each component of the module is responsible for and how they interact. You can add this as a docstring to the class definition (https://www.python.org/dev/peps/pep-0257/) or add it a README file.