### PR TITLE
Fix coreir_compile.sh for mac

### DIFF
--- a/aetherling/coreir_compile.sh
+++ b/aetherling/coreir_compile.sh
@@ -3,4 +3,4 @@
 #  2. board version / output directory (IceStick or HX8K)
 # edit output directory for each user
 
-coreir -i $1.json -o ../$2/build/$1.v -p 'rungenerators,wireclocks-coreir' -n 'aetherlinglib,commonlib,mantle,coreir,global' --load_libs '/usr/lib/libcoreir-aetherlinglib.so,/usr/lib/libcoreir-commonlib.so'
+coreir -i $1.json -o ../$2/build/$1.v -p 'rungenerators,wireclocks-coreir' -n 'aetherlinglib,commonlib,mantle,coreir,global' --load_libs 'aetherlinglib,commonlib'


### PR DESCRIPTION
Mac puts the shared objects in a different location (/usr/local/lib rather than /usr/lib) and calls them different things (.dylib rather than .so). The coreir_compile.sh script doesn't work on mac without the below changes due to these differences. The new version should work on mac and linux. Loading libs using names rather than by path should work as long as the user's $PATH is set correctly. 